### PR TITLE
Support floats as clique data types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,21 @@ PULSE_TESTS = worker_pool_pulse
 all: deps compile
 
 compile: deps
-	./rebar compile
+	./rebar3 compile
 
 deps:
-	./rebar get-deps
+	./rebar3 get-deps
 
 clean:
-	./rebar clean
+	./rebar3 clean
 
 distclean: clean
-	./rebar delete-deps
+	./rebar3 delete-deps
 
 # You should 'clean' before your first run of this target
 # so that deps get built with PULSE where needed.
 pulse:
-	./rebar compile -D PULSE
-	./rebar eunit -D PULSE skip_deps=true suite=$(PULSE_TESTS)
+	./rebar3 compile -D PULSE
+	./rebar3 eunit -D PULSE skip_deps=true suite=$(PULSE_TESTS)
 
 include tools.mk

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 ]}.
 
 {deps, [
-  {cuttlefish, ".*", {git, "https://github.com/helium/cuttlefish.git", {branch, "develop"}}}
+  {cuttlefish, {git, "https://github.com/helium/cuttlefish.git", {branch, "develop"}}}
 ]}.
 {plugins, [{rebar_erl_vsn, "~>0.2.0"}]}.
 {provider_hooks, [{pre, [{compile, erl_vsn}]}]}.

--- a/src/clique_csv_writer.erl
+++ b/src/clique_csv_writer.erl
@@ -79,7 +79,7 @@ format_val(V) when is_binary(V) ->
     format_val(unicode:characters_to_list(V, utf8));
 format_val(V) when is_float(V) ->
     %% cuttlefish provides 6 decimals, so we will too.
-    format_val(float_to_list(V, [{decimals, 6}, compact]);
+    format_val(float_to_list(V, [{decimals, 6}, compact]));
 format_val(Str0) when is_list(Str0) ->
     %% TODO: This could probably be done more efficiently.
     %% Maybe we could write a strip func that works directly on iolists?

--- a/src/clique_csv_writer.erl
+++ b/src/clique_csv_writer.erl
@@ -77,6 +77,9 @@ format_val(V) when is_integer(V) ->
     format_val(integer_to_list(V));
 format_val(V) when is_binary(V) ->
     format_val(unicode:characters_to_list(V, utf8));
+format_val(V) when is_float(V) ->
+    %% cuttlefish provides 6 decimals, so we will too.
+    format_val(float_to_list(V, [{decimals, 6}, compact]);
 format_val(Str0) when is_list(Str0) ->
     %% TODO: This could probably be done more efficiently.
     %% Maybe we could write a strip func that works directly on iolists?

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -332,8 +332,12 @@ spec() ->
 
 dt_validate_spec() ->
     Cmd = ["riak-admin", "test", "something"],
-    KeySpecs = [clique_spec:make({sample_size, [{datatype, integer},
-                                                {validator, fun greater_than_zero/1}]})],
+    KeySpecs = [
+                clique_spec:make({sample_size, [{datatype, integer},
+                                                {validator, fun greater_than_zero/1}]}),
+                clique_spec:make({float_precision, [{datatype, float},
+                                                {validator, fun greater_than_zero/1}]})
+               ],
     FlagSpecs = [clique_spec:make({node, [{shortname, "n"},
                                           {longname, "node"},
                                           {datatype, atom},
@@ -437,6 +441,13 @@ arg_datatype_test() ->
 
     InvalidTypeArg = [{"sample_size", "A"}],
     ?assertMatch({error, _}, validate({Spec, InvalidTypeArg, [], []})).
+
+arg_float_test() ->
+    Spec = dt_validate_spec(),
+    Cmd = element(1, Spec),
+    ValidArg = [{"float_precision", "1.2"}],
+    {undefined, Cmd, ConvertedArgs, [], []} = validate({Spec, ValidArg, [], []}),
+    ?assertEqual(ConvertedArgs, [{float_precision, 1.2}]).
 
 arg_validation_test() ->
     Spec = dt_validate_spec(),

--- a/src/clique_table.erl
+++ b/src/clique_table.erl
@@ -259,6 +259,9 @@ align(undefined, Size) ->
     align("", Size);
 align(Str, Size) when is_integer(Str) ->
     align(integer_to_list(Str), Size);
+align(Str, Size) when is_float(Str) ->
+    %% cuttlefish provides 6 decimals; we will too.
+    align(float_to_list(Str, [{decimals, 6}, compact]), Size);
 align(Str, Size) when is_binary(Str) ->
     align(unicode:characters_to_list(Str, utf8), Size);
 align(Str, Size) when is_atom(Str) ->

--- a/tools.mk
+++ b/tools.mk
@@ -1,4 +1,4 @@
-REBAR ?= ./rebar
+REBAR ?= ./rebar3
 
 .PHONY: compile-no-deps test docs xref dialyzer-run dialyzer-quick dialyzer \
 		cleanplt


### PR DESCRIPTION
Problems to solve:
* Clique only supports integers currently
* Repo still uses old style rebar2 config and makefile

Solutions:
* Enable float conversions to strings where appropriate, using cuttlefish as a guide for precision (cuttlefish uses 6 decimal places, so we will also use 6)
* Convert makefile and rebar.config appropriately.

[story](https://app.clubhouse.io/hlm/story/5698/fix-clique-csv-mode-to-print-floats)

Semi-related PR to fix the upstream "erl_vsn" plugin warnings and typos: https://github.com/project-fifo/rebar_erl_vsn/pull/7